### PR TITLE
feature: déblocage de certains choix selon les objets possédés dans l'inventaire

### DIFF
--- a/data/story.js
+++ b/data/story.js
@@ -1,67 +1,92 @@
 const story = {
     0: {
-        text: "Après une journée des plus ennuyeuses, à traiter un énième conflit de voisinnage, te voilà assis dans ton bureau miteux, les jambes allongées sur le bureau, un verre de whisky bon marché dans la main. Quelqu'un toque à la porte, surement un client, à moins que ça ne soit encore un voisin agaçant.",
-        choices: [
-            { text: "Se lever et aller ouvrir la porte", next: 1 },
-            { text: "Ignorer et continuer à boire jusqu'à l'heure du coucher", next: 2, effects: [{ stat: "charisme", value: -1 }]}
-        ]
+      text: "La nuit est tombée sur la ville. Une silhouette se faufile dans la ruelle derrière ton bureau. Une voix t'appelle depuis l'ombre.",
+      choices: [
+        { text: "Répondre à la voix", next: 1 },
+        { text: "Sortir ton arme et avancer prudemment", next: 2, effects: [{ stat: "charisme", value: -1 }] },
+        { text: "Ignorer et retourner à l'intérieur", next: 3 }
+      ]
     },
+  
     1: {
-        text: "Tu ouvres la porte, un homme d'une trentaine d'années en trench-coat te regarde, visiblement un peu anxieux vu la manière dont il triture ses doigts. \"J'ai ... une affaire pour vous.\", dit-il d'une voix nerveuse. \"Mais elle est un peu dangereuse.\"",
-        choices: [
-            { text: "Accepter de l'écouter", next: 3, effects: [{ stat: "deduction", value: +1 }] },
-            { text: "Refuser, t'as pas le temps de ça", next: 4 }
-        ]
+      text: "La voix t’invite à t’approcher. Tu aperçois un jeune garçon, paniqué.",
+      choices: [
+        { text: "L’écouter attentivement", next: 4, effects: [{ stat: "deduction", value: 1 }] },
+        { text: "Lui donner une potion de calme (objet requis)", next: 5, requiredObject: "Potion de calme" }
+      ]
     },
+  
     2: {
-        text: "Tu décides d'ignorer la porte et tu termines ton whisky. Le lendemain, tu te réveilles avec la pire gueule de bois de ta vie... et une facture impayée.",
-        choices: [
-            { text: "Recommencer", next: 0 }
-        ]
+      text: "Tu avances, arme à la main. La silhouette recule et glisse un papier dans ta poche sans un mot.",
+      choices: [
+        { text: "Récupérer le papier", next: 6, items: [{ object: "Billet anonyme", type: "infos", content: "« Rendez-vous au quai 17 avant minuit. Seul. »" }] },
+        { text: "Ignorer le papier et retourner au bureau", next: 3 }
+      ]
     },
+  
     3: {
-        text: "Tu retournes t'asseoir, l'invitant à faire de même et tu l'écoute attentivement. \"Un bien précieux m'a été dérobé ... et avant de me dire d'aller voir la police, je préfère éviter. J'ai toutes les raisons de croire que ma femme bien aimée est impliquée et j'ai besoin que vous enquêtiez sur elle ... et que vous trouviez à qui elle a pu apporter cet objet.\" expliqua-t-il.",
-        choices: [
-            { text: "Lui demander plus d'informations sur le bien dérobé", next: 5, effects: [{ stat: "deduction", value: 1 }] },
-            { text: "Accepter l'affaire et prendre une avance", next: 5, effects: [{ stat: "charisme", value: 1 }], items: [{ object: "Potion de réflexion", type: "affectStats", use: { stat: "deduction", value: 2} }] }
-        ]
+      text: "Tu retournes au bureau. La pluie s’intensifie dehors. Quelque chose cloche.",
+      choices: [
+        { text: "Examiner ton bureau", next: 7 },
+        { text: "Boire un verre pour te détendre", next: 7, effects: [{ stat: "deduction", value: -1 }] }
+      ]
     },
+  
     4: {
-        text: "L'homme écarquille les yeux, un peu paniqué face à ton refus instantané. \'Attendez ! Je peux payer, grassement ... je suis prêt à donner toutes mes économies ! Tenez, je vous donne même une avance de 100 crédits !\" s'écria-t-il.",
-        choices: [
-            { text: "Être payé grassement t'intéresse, tu l'écoutes.", next: 3, items: [{ object: "100 crédits"}] },
-            { text: "Tu n'y crois absolument pas, le mettre dehors", next: 2, effects: [{ stat: "charisme", value: -1 }] }
-        ]
+      text: "Le garçon te raconte qu’un homme étrange a emmené sa sœur. Il te tend un pendentif trouvé sur place.",
+      choices: [
+        { text: "Prendre le pendentif", next: 8, items: [{ object: "Pendentif" }] },
+        { text: "Refuser et lui dire de voir la police", next: 3 }
+      ]
     },
+  
     5: {
-        text: "\"Il s'agit d'une relique très ancienne ... quelque chose qui comporte un grand pouvoir. Ecoutez attentivement : il ne faudra surtout pas que vous la touchiez, elle pourrait vous ... tuer. Vous devrez être très prudent.\" dit-il, le regard sérieux. Il te tend notamment un document, sur laquelle est affichée une photo de sa femme et quelques informations.",
-        choices: [
-            { text: "Tu prends le document, tu te lèves et tu quittes le bureau sans attendre.", next: 7, items: [{ object: "Document du client", type: "infos", content: "Ce document contient l'adresse du suspect ainsi qu'une photo de la femme du client." }]},
-            { text: "Tu prends le document, tu le ranges, et tu demandes plus d'informations sur cette relique si dangereuse.", next: 8, items: [{ object: "Document du client", type: "infos", content: "Ce document contient l'adresse du suspect ainsi qu'une photo de la femme du client." }]},
-            { text: "Tu ouvres un tiroir et prend ton carnet, hors de question de toucher ce document.", next: 6, items: [{ object: "Carnet", type: "infos", content: "Des notes sur de vieilles affaires, la plupart du temps totalement inintéressantes. Sur une page cornée, l'adresse de ton bar favoris." }]}
-        ]
+      text: "Tu lui donnes la potion. Il se calme immédiatement et te murmure un nom : « Le Corbeau ».",
+      choices: [
+        { text: "Prendre des notes", next: 8, items: [{ object: "Note 'Le Corbeau'", type: "infos", content: "Nom d’un criminel notoire dans le réseau des docks. Quai 17." }] }
+      ]
     },
+  
     6: {
-        text: "Tu prends ton carnet poussiéreux puisque tu n'as pas les moyens de t'acheter la tablette dernier cri, et tu notes tout ça.",
-        choices: [
-            { text: "END", next: 0}
-        ]
+      text: "Le billet t’intrigue. Tu décides de suivre l’indice seul.",
+      choices: [
+        { text: "Aller au quai 17", next: 9, requiredStat: { stat: "charisme", value: 2 } },
+        { text: "Chercher d’autres informations avant", next: 7 }
+      ]
     },
+  
     7: {
-        text: "Tu quittes le bureau sans attendre, prêt à te lancer dans cette enquête...",
-        choices: [
-            { text: "Mais pas avant un verre. Tu te diriges vers le bar le plus proche.", next: 0 },
-        ]
+      text: "Rien de nouveau au bureau. Tu prends une décision.",
+      choices: [
+        { text: "Aller au quai 17", next: 9 },
+        { text: "Mettre fin à l’enquête ici", next: 99 }
+      ]
     },
+  
     8: {
-        text: "\"La relique ... écoutez, moi-même je ne sais pas trop ce qu'elle contient. Je sais seulement qu'elle ne vient pas de notre planète. C'est très délicat...\"",
-        choices: [
-            { text: "Tu n'as jamais aimé les autorités. Tu acceptes l'affaire et tu te lèves, prêt à partir.", next: 7 },
-            { text: "Sortir un contrat et exiger la somme de 5000 crédits en paiement", next: 0, requiredStat: { stat: "charisme", value: 2 },effects: [{ stat: "chance", value: +1 }] },
-            { text: "Sortir un contrat et exiger la somme de 8000 crédits en paiement", next: 0, requiredStat: { stat: "charisme", value: 4 }, effects: [{ stat: "chance", value: +2 }] },
-            { text: "Sortir un contrat et exiger la somme de 1000 crédits en paiement", next: 0, requiredStat: { stat: "charisme", value: 1 }},
-        ]
+      text: "Grâce aux indices du garçon, tu traces une piste jusqu’aux anciens entrepôts.",
+      choices: [
+        { text: "Explorer discrètement", next: 9, effects: [{ stat: "deduction", value: 1 }] },
+        { text: "Y aller de front, confiant", next: 9, effects: [{ stat: "charisme", value: -1 }] }
+      ]
+    },
+  
+    9: {
+      text: "Tu arrives au quai 17. Un homme t’attend dans l’ombre. Il sourit.",
+      choices: [
+        { text: "L’affronter verbalement", next: 99, requiredStat: { stat: "charisme", value: 3 } },
+        { text: "Lui montrer le pendentif", next: 99, requiredObject: "Pendentif" },
+        { text: "Fuir discrètement", next: 99 }
+      ]
+    },
+  
+    99: {
+      text: "Fin de la démo. Tu peux relancer l’histoire pour tester d’autres chemins.",
+      choices: [
+        { text: "Recommencer", next: 0 }
+      ]
     }
-};
-
-export default story;
+  };
+  
+  export default story;
+  

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,8 +3,16 @@ import story from "@/data/story";
 import HUD from "@/components/HUD";
 
 export default function Home() { 
-  const { step, makeChoice, stats } = useGameStore();
+  const { step, makeChoice, stats, inventory } = useGameStore();
   const scene = story[step]; // récupération de la scène actuelle
+
+  // Un choix peut être impossible à choisir si le joueur n'a pas la stat ou l'objet requis
+  const isChoiceDisabled = (choice) => {
+    const lacksStat = choice.requiredStat && stats[choice.requiredStat.stat] < choice.requiredStat.value;
+    const lacksObject = choice.requiredObject && !inventory.some(item => item.object.toLowerCase() === choice.requiredObject.toLowerCase());
+
+    return lacksStat || lacksObject;
+  }
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-gray-900 text-white">
@@ -14,8 +22,8 @@ export default function Home() {
 
       <div className="mt-6 flex flex-col gap-4">
         { scene.choices.map((choice, index) => {
-          const isDisabled = choice.requiredStat && stats[choice.requiredStat.stat] < choice.requiredStat.value;
-         
+          const isDisabled = isChoiceDisabled(choice);
+
           return (
             <div>
               <button key={index} 
@@ -25,7 +33,19 @@ export default function Home() {
                 }}
                 disabled={isDisabled}
               >
-                {choice.text} {isDisabled && `(Requis: ${choice.requiredStat.stat} ${choice.requiredStat.value}+)`}
+                {choice.text}
+
+                {/* Affichage des éléments requis */}
+                {choice.requiredStat && (
+                  <span className={`text-sm ${isDisabled ? "text-red-400" : "text-green-400"} ml-2`}>
+                  (Requis : {choice.requiredStat.stat} {choice.requiredStat.value}+)
+                </span>                  
+                )}
+                {choice.requiredObject && (
+                  <span className={`text-sm ${isDisabled ? "text-red-400" : "text-green-400"} ml-2`}>
+                  (Requis : {choice.requiredObject})
+                </span>                  
+                )}
               </button>
             </div>
           );


### PR DESCRIPTION
# 🚀 Pull Request

## ✨ Description
Des options sont désactivées si le joueur n'a pas l'objet requis dans son inventaire. 
Affichage de l'objet requis au niveau du choix.
Un choix peut nécessiter un certain niveau sur une statistique ET un objet particulier
Ces objets qui débloquent des choix ne sont pas des objets utilisables par le joueur.

## ✅ Checklist

- [x] Code testé localement
- [x] Comportement responsive vérifié
- [x] Traces de debug supprimés
- [x] Commentaires réalisés
- [x] Style cohérent avec le reste du projet
- [x] Comportement attendu validé

## 🖼️ Captures d’écran (si nécessaire)
![image](https://github.com/user-attachments/assets/751a705e-f6d3-4a7f-9217-eb6cf9ce26ec)
![image](https://github.com/user-attachments/assets/706440f7-59ee-491c-bda2-6d75996c1284)

## 📚 Notes
/ 

## 🛠️ Issue(s) associée(s)
Closes #11 