### PR TITLE
refactor: harmonise les noms de stats sans accents

### DIFF
--- a/components/HUD.js
+++ b/components/HUD.js
@@ -24,11 +24,11 @@ export default function HUD() {
       {/* Zone des compétences */}
       <div className="flex gap-4 relative max-w-full sm:max-w-[80%]">
         <Tooltip.Provider delayDuration={300}>
-          {["charisme", "déduction", "chance"].map((stat) => (
+          {Object.keys(stats).map((stat) => (
             <div key={stat} className="relative">
               <Tooltip.Root>
                 <Tooltip.Trigger>
-                  <p>{stat === "charisme" ? "💬" : stat === "déduction" ? "🕵️" : "🍀"} {stats[stat]}</p>
+                  <p>{stat === "charisme" ? "💬" : stat === "deduction" ? "🕵️" : "🍀"} {stats[stat]}</p>
                 </Tooltip.Trigger>
                 <Tooltip.Content className="TooltipContent bg-gray-800 rounded px-2 py-1 text-white border border-gray-600 shadow-md text-sm" sideOffset={8}>
                   { stat.charAt(0).toUpperCase() + stat.slice(1) }

--- a/store/gameStore.js
+++ b/store/gameStore.js
@@ -6,7 +6,7 @@ const useGameStore = create(devtools((set) => ({
     choices: [],
     stats: {
         charisme: 1,
-        déduction: 1,
+        deduction: 1,
         chance: 1
     },
     inventory: [],


### PR DESCRIPTION
# 🚀 Pull Request

## ✨ Description
- Remplace 'déduction' par 'deduction' dans l'objet stats
- Adapte les composants qui utilisaient les anciennes clés

## ✅ Checklist

- [ ] Code testé localement
- [ ] Comportement responsive vérifié
- [ ] Traces de debug supprimés
- [ ] Commentaires réalisés
- [ ] Style cohérent avec le reste du projet
- [ ] Comportement attendu validé

## 🖼️ Captures d’écran (si nécessaire)

## 📚 Notes

## 🛠️ Issue(s) associée(s)
Closes #23 