### PR TITLE
fix: corrige l'affichage d'un seul objet dans l'inventaire

### DIFF
--- a/store/gameStore.js
+++ b/store/gameStore.js
@@ -55,17 +55,17 @@ const useGameStore = create(devtools((set) => ({
     },
 
     addItem: (item) => set((state) => ({
-        inventory: state.inventory.some(i => i.object === item.object)
+        inventory: state.inventory.some(i => i.id === item.id)
             ? state.inventory
             : [...state.inventory, item]
     })),
 
     useItem: (item) => set((state) => {
-        useGameStore.getState().updateStats(item.use.stat, item.use.value);
+        useGameStore.getState().updateStats(item.affected_stat, item.affected_stat_value);
 
         return {
             // On retire l'objet de l'inventaire
-            inventory: state.inventory.filter(i => i.object !== item.object)
+            inventory: state.inventory.filter(i => i.id !== item.id)
         };
     }),    
 


### PR DESCRIPTION
# 🚀 Pull Request

## ✨ Description

Corrige un bug où un seul objet s'affichait dans l'inventaire, même après en avoir récupéré plusieurs.

- Remplacement de la vérification `item.object` par `item.id` dans `addItem()`
- `item.id` étant unique, cela évite les faux positifs et permet d’ajouter correctement plusieurs objets différents

## ✅ Checklist

- [x] Code testé localement
- [x] Comportement responsive vérifié
- [x] Traces de debug supprimés
- [x] Commentaires réalisés
- [x] Style cohérent avec le reste du projet
- [x] Comportement attendu validé

## 🖼️ Captures d’écran (si nécessaire)
/ 

## 📚 Notes
/

## 🛠️ Issue(s) associée(s)

Closes #27 